### PR TITLE
Fixed performance issue by avoiding to call s:py_core_load() if disabled

### DIFF
--- a/autoload/trans.vim
+++ b/autoload/trans.vim
@@ -163,17 +163,17 @@ fun! trans#init() "{{{
     call trans#default("g:trans_set_echo" , 1)
 
     if !exists("g:trans_has_python") || g:trans_has_python != 0
-    if has("python") "{{{
-        call trans#default("g:trans_has_python", 2)
-        let s:py="py"
-        call s:py_core_load()
-    elseif has("python3")
-        call trans#default("g:trans_has_python", 3)
-        let s:py="py3"
-        call s:py_core_load()
-    else
-        let g:trans_has_python = 0
-    endif "}}}
+        if has("python") "{{{
+            call trans#default("g:trans_has_python", 2)
+            let s:py="py"
+            call s:py_core_load()
+        elseif has("python3")
+            call trans#default("g:trans_has_python", 3)
+            let s:py="py3"
+            call s:py_core_load()
+        else
+            let g:trans_has_python = 0
+        endif "}}}
     endif
 
     call trans#data#init()


### PR DESCRIPTION
Hi

First off all thank you very much for this nice plugin. It is exactly what I was looking for …

I found a performance issue and fixed it.

Before the change the startup time looked like this:
vim --startuptime vim.log -c:q && vim vim.log
111.519  003.536  002.629: sourcing ~/.vim/bundle/vim-easymotion/plugin/EasyMotion.vim
112.412  000.592  000.592: sourcing ~/.vim/bundle/trans.vim/autoload/trans.vim
152.550  000.358  000.358: sourcing ~/.vim/bundle/trans.vim/autoload/trans/data.vim
152.781  041.140  040.190: sourcing ~/.vim/bundle/trans.vim/plugin/trans.vim
153.267  000.187  000.187: sourcing /usr/share/vim/vim73/plugin/getscriptPlugin.vim

And now it looks like this if you set g:trans_has_python = 0 before the plugin
is loaded:
109.487  003.587  002.720: sourcing ~/.vim/bundle/vim-easymotion/plugin/EasyMotion.vim
110.373  000.585  000.585: sourcing ~/.vim/bundle/trans.vim/autoload/trans.vim
111.051  000.320  000.320: sourcing ~/.vim/bundle/trans.vim/autoload/trans/data.vim
111.216  001.608  000.703: sourcing ~/.vim/bundle/trans.vim/plugin/trans.vim
111.589  000.095  000.095: sourcing /usr/share/vim/vim73/plugin/getscriptPlugin.vim

vim --cmd 'profile start trans.profile' --cmd 'profile! file ~/.vim/bundle/trans.vim/*' -c 'q' && vim trans.profile

```
vim --cmd 'profile start trans.profile' --cmd 'profile! file ~/.vim/bundle/trans.vim/*' -c 'q' && vim trans.profile
1           0.000006    if !exists("g:trans_has_python") || g:trans_has_python != 0
1           0.000004        if has("python") "{{{
1   0.000026    0.000008            call trans#default("g:trans_has_python", 2)
1           0.000003            let s:py="py"
1   0.038763    0.000012            call s:py_core_load()
1           0.000005        elseif has("python3")
                        call trans#default("g:trans_has_python", 3)
                        let s:py="py3"
                        call s:py_core_load()
                    else
                        let g:trans_has_python = 0
                    endif "}}}
1           0.000001    endif
```
